### PR TITLE
Update tests to show correct Capybara RSpec expectation use

### DIFF
--- a/spec/add_to_cart_spec.rb
+++ b/spec/add_to_cart_spec.rb
@@ -4,19 +4,24 @@ describe "Cart" do
   before { visit 'http://www.saucedemo.com/inventory.html'}
 
   it "adds one" do
+    # find('.inventory_item:first-child').click_button('ADD TO CART')
+    # click_button('ADD TO CART', match: :first)
+    # click_button(class: 'add-to-cart-button', match: :first)
+    # first(:button, 'ADD TO CART').click
+    # first(:button, class: ['add-to-cart-button']).click
     first('.add-to-cart-button').click
 
-    expect(first('.shopping_cart_badge').text).to eq '1'
+    expect(page).to have_css('.shopping_cart_badge', exact_text: '1')
     visit 'https://www.saucedemo.com/cart.html'
-    expect(all('.inventory_item_name').size).to eq 1
+    expect(page).to have_css('.inventory_item_name', count: 1)
   end
 
   it "adds two" do
     first('.add-to-cart-button').click
     first('.add-to-cart-button').click
 
-    expect(first('.shopping_cart_badge').text).to eq '2'
+    expect(page).to have_css('.shopping_cart_badge', exact_text: '2')
     visit 'https://www.saucedemo.com/cart.html'
-    expect(all('.inventory_item_name').size).to eq 2
+    expect(page).to have_css('.inventory_item_name', count: 2)
   end
 end

--- a/spec/login_fail_spec.rb
+++ b/spec/login_fail_spec.rb
@@ -4,11 +4,11 @@ describe "Authentication" do
   before { visit 'http://www.saucedemo.com' }
 
   it "fails" do
-    first('[data-test=username]').send_keys 'locked_out_user'
-    first('[data-test=password]').send_keys 'secret_sauce'
+    fill_in 'Username', with: 'locked_out_user'
+    fill_in 'Password', with: 'secret_sauce'
 
-    first('[type=submit]').click
+    click_button('LOGIN')
 
-    expect(first('.error-button')).to_not be_nil
+    expect(page).to have_css('.error-button')
   end
 end

--- a/spec/login_success_spec.rb
+++ b/spec/login_success_spec.rb
@@ -4,12 +4,11 @@ describe "Authentication" do
   before { visit 'http://www.saucedemo.com' }
 
   it "successful" do
+    fill_in 'Username', with: 'standard_user'
+    fill_in 'Password', with: 'secret_sauce'
 
-    first('[data-test=username]').send_keys 'standard_user'
-    first('[data-test=password]').send_keys 'secret_sauce'
+    click_button('LOGIN')
 
-    first('[type=submit]').click
-
-    expect(current_url).to eq 'https://www.saucedemo.com/inventory.html'
+    expect(page).to have_current_path('https://www.saucedemo.com/inventory.html')
   end
 end

--- a/spec/remove_from_cart_spec.rb
+++ b/spec/remove_from_cart_spec.rb
@@ -8,9 +8,9 @@ describe "Cart" do
     first('.add-to-cart-button').click
     first('.remove-from-cart-button').click
 
-    expect(first('.shopping_cart_badge').text).to eq '1'
+    expect(page).to have_css('.shopping_cart_badge', exact_test: '1')
     visit 'https://www.saucedemo.com/cart.html'
 
-    expect(all('.inventory_item_name').size).to eq 1
+    expect(page).to have_css('.inventory_item_name', count: 1)
   end
 end


### PR DESCRIPTION
@titusfortner This fixes the expectations use with Capybara. I also provided multiple options for the button clicking.  The button clicking really depends on exactly what the tester is trying to verify in the test.  These have not been run so there could be typos.